### PR TITLE
docs(GS-45): Fix docs examples

### DIFF
--- a/src/main/java/com/example/storehouse/dto/ItemStorehouseTo.java
+++ b/src/main/java/com/example/storehouse/dto/ItemStorehouseTo.java
@@ -16,12 +16,12 @@ public class ItemStorehouseTo {
 
     @NotNull
     @JsonProperty(value = "id")
-    @Schema(description = "id", example = "1")
+    @Schema(name = "id", description = "Storehouse id", example = "1000")
     Integer storehouseId;
 
     @NotNull
     @Min(value = 1)
-    @Schema(description = "Quantity of Items stored in storehouseId Storehouse", example = "25")
+    @Schema(description = "Quantity of Items stored in Storehouse with specified id", example = "25")
     Integer quantity;
 
 }

--- a/src/main/java/com/example/storehouse/dto/ItemTo.java
+++ b/src/main/java/com/example/storehouse/dto/ItemTo.java
@@ -8,9 +8,7 @@ import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Data
 @Builder
@@ -29,21 +27,22 @@ public class ItemTo {
 
     @NotNull
     @NotBlank
-    @Schema(description = "Item sku", example = "#Supplier_name_code_sku")
+    @Schema(description = "Item SKU", example = "#Supplier_name_code_sku")
     String sku;
 
     @NotNull
-    @Schema(description = "Item supplier data: supplier id and supplier name", example = "{id = 1; name = TheBestSupplier}")
+    @Schema(description = "Item supplier data: supplier id and name", example = "{\"id\": 1000, \"name\": \"TheBestSupplier\"}")
     SupplierTo supplier;
 
     @NotNull
-    @Schema(description = "Item categories data: category id and category name" , example = "{id = 1; name = TheBestCategory}")
-        //TODO only one category or several categories for one item???
+    @Schema(description = "Item categories data: category id and name", example = "[{\"id\": 1000, \"name\": \"TheBestCategory\"}]")
+    //TODO only one category or several categories for one item???
     List<CategoryTo> categories;
 
     @NotNull
     @JsonProperty(value = "storehouses_balance")
-    @Schema(description = "ItemStorehouse data: storehouse and quantity of item in this storehouse", example = "{id = 1; qty = 25;}")
+    @Schema(description = "ItemStorehouse data: storehouse and quantity of item in this storehouse",
+        example = "[{\"id\": 1000, \"quantity\": 25}, {\"id\": 1001, \"quantity\": 15}]")
     List<ItemStorehouseTo> itemsStorehousesTo;
 
 }

--- a/src/main/java/com/example/storehouse/dto/RestResponseTo.java
+++ b/src/main/java/com/example/storehouse/dto/RestResponseTo.java
@@ -9,10 +9,10 @@ import lombok.Data;
 @Schema(description = "Entity: RestResponse")
 public class RestResponseTo<T> {
 
-    @Schema(description = "Response status", example = "404 NOT_FOUND")
+    @Schema(description = "Response status")
     private String responseStatus;
 
-    @Schema(description = "Response error message", example = "Item was not found.")
+    @Schema(description = "Response error message")
     private String errorMessage;
 
     @Schema(description = "Response data")

--- a/src/main/java/com/example/storehouse/dto/SupplierTo.java
+++ b/src/main/java/com/example/storehouse/dto/SupplierTo.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 @Schema(description = "Entity: Supplier")
 public class SupplierTo {
 
-    @Schema(description = "Identifier")
+    @Schema(description = "Identifier", example = "1001")
     Integer id;
 
     @NotNull

--- a/src/test/idea-http-client/items.http
+++ b/src/test/idea-http-client/items.http
@@ -25,7 +25,7 @@ Content-Type: application/json
 
 {
   "name": "Moloko Burenka2",
-  "sku": "#moloko784",
+  "sku": "#moloko785",
   "supplier": {
     "id": 1001
   },
@@ -36,11 +36,11 @@ Content-Type: application/json
   ],
   "storehouses_balance": [
     {
-      "storehouse_id": 1001,
+      "id": 1001,
       "quantity": 14
     },
     {
-      "storehouse_id": 1000,
+      "id": 1000,
       "quantity": 18
     }
   ]


### PR DESCRIPTION
Предлагаю всё же, при изменении документации с заменой автоматически сгенерированных примеров на свои, добавлять валидные данные. Чтобы их можно было использовать при помощи _Try it out_ кнопки.
P.S. Пока не нашёл, как убрать `"storehouses_balance": [...]` из примеров `ItemsController` для `GET` запросов.